### PR TITLE
feat: enable environment-specific database configurations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -167,6 +167,8 @@ dummy_tester/
 tests/
 experimental/
 price-tracker-api/
+mongodata/
+pgdata/
 
 .gitignore
 LICENSE

--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,8 @@ logs/
 redis_data/
 rabbitmq_data/
 dummy_tester/
+mongodata/
+pgdata/
 
 00.py
 tmp.py

--- a/app/db/db_mongo.py
+++ b/app/db/db_mongo.py
@@ -22,7 +22,7 @@ class MongoDBClient:
 
             # Connect to MongoDB
             self.client = MongoClient(
-                self.mongo_uri, tls=True, tlsAllowInvalidCertificates=True
+                self.mongo_uri
             )
             self.db = self.client[self.db_name]
             self.collection = self.db[self.collection_name]

--- a/app/utils/config.py
+++ b/app/utils/config.py
@@ -12,15 +12,21 @@ class Config:
     TABLE_NAME = "products"
     ALLOWED_ORIGINS = ["*"]
 
+    DEPLOYMENT_ENV = os.getenv("DEPLOYMENT_ENV")
+
     # MongoDB Configuration
     MONGO_USERNAME = os.getenv("MONGO_USERNAME")
     MONGO_PASSWORD = os.getenv("MONGO_PASSWORD")
     MONGO_DB_NAME = os.getenv("MONGO_DB_NAME")
     MONGO_COLLECTION_NAME = os.getenv("MONGO_COLLECTION_NAME")
-    MONGO_URI = os.getenv("MONGO_URI")
+    MONGO_URI = os.getenv("MONGO_URI_LOCAL")
+    if DEPLOYMENT_ENV == "remote":
+        MONGO_URI = os.getenv("MONGO_URI_REMOTE")
 
-    # PostgreSQL Configuration
-    POSTGRES_URI = os.getenv("POSTGRES_URI")
+    # PostgreSQL Configuration (Local and Remote)
+    POSTGRES_URI = os.getenv("POSTGRES_URI_LOCAL")
+    if DEPLOYMENT_ENV == "remote":
+        POSTGRES_URI = os.getenv("POSTGRES_URI_REMOTE")
 
     # Flask Configuration
     FLASK_ENV = os.getenv("FLASK_ENV", "production")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     depends_on:
       - rabbitmq
       - redis
+      - mongo
+      - postgres
     env_file:
       - .env  # Load environment variables from the .env file
     volumes:
@@ -20,6 +22,8 @@ services:
       - web
       - rabbitmq
       - redis
+      - mongo
+      - postgres
     env_file:
       - .env  # Share the same environment variables as the web service
 
@@ -53,9 +57,39 @@ services:
     environment:
       - REDIS_HOSTS=local:redis:6379  # Connect to Redis container
 
+  mongo: # MongoDB service
+    image: mongo:latest # Use a specific version for better control
+    container_name: mongo_local
+    env_file:
+      - .env # Load environment variables from the .env file
+    ports:
+      - "${MONGO_PORT}:27017" # Expose MongoDB port
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_USERNAME} # Root user for initial setup
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD} # Root user password
+      MONGO_INITDB_DATABASE: ${MONGO_DB_NAME} # Database to create on startup
+    volumes:
+      - ./mongodata:/data/db # Persist MongoDB data
+
+  postgres:
+    image: postgres:latest # Use a specific version for better control
+    container_name: postgres_local
+    ports:
+      - "${POSTGRES_PORT}:5432"
+    environment:
+      POSTGRES_USER: ${POSTGRES_USERNAME} # Default Postgres user
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD} # Default Postgres password
+      POSTGRES_DB: ${POSTGRES_DB_NAME} # Default Postgres database
+    volumes:
+      - ./pgdata:/var/lib/postgresql/data # Persist Postgres data
+
 volumes:
   logs:
     driver: local  # Use local driver for named volume
+  pgdata:
+    driver: local # Use local driver for named volume
+  mongodata:
+    driver: local # Use local driver for named volume
 
 # Uncomment to use secrets in production
 # secrets:


### PR DESCRIPTION

This pull request includes several changes to add support for MongoDB and PostgreSQL services in the application's Docker setup, as well as updates to the configuration handling for different deployment environments.

### Docker and Environment Configuration:

* [`.dockerignore`](diffhunk://#diff-2f754321d62f08ba8392b9b168b83e24ea2852bb5d815d63e767f6c3d23c6ac5R170-R171): Added `mongodata/` and `pgdata/` directories to the `.dockerignore` file to prevent them from being included in Docker builds.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R10-R11): Added MongoDB and PostgreSQL services, including environment variables, ports, and volumes for data persistence. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R10-R11) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R25-R26) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R60-R92)

### Database Initialization:

* [`app/db/db_mongo.py`](diffhunk://#diff-b46dddf02be8a350651b53f912df6132a50b01e50215703018221d213bd35b08L25-R25): Removed the `tls` and `tlsAllowInvalidCertificates` options from the MongoDB client initialization.

### Configuration Management:

* [`app/utils/config.py`](diffhunk://#diff-d2ca832c40bc9305ef22d1e6d233cf1354444d77370e95eb363f7dbdb580588fR15-R29): Added `DEPLOYMENT_ENV` to manage different configurations for local and remote deployments. Updated MongoDB and PostgreSQL URI configurations to use different environment variables based on the deployment environment.