### PR TITLE
Fixed typo. [webcode -> web_code]

### DIFF
--- a/app/db/jobs_crud.py
+++ b/app/db/jobs_crud.py
@@ -26,7 +26,7 @@ class Jobs(Base):
     __tablename__ = "jobs"
 
     job_id = Column(String, primary_key=True, nullable=False, unique=True)
-    webcode = Column(String, nullable=False)
+    web_code = Column(String, nullable=False)
     status = Column(String, nullable=False)
     result = Column(String, nullable=True)
     product_id = Column(Integer, nullable=True)
@@ -46,7 +46,7 @@ class Jobs(Base):
             str: A string representation of the job record.
         """
         return (
-            f"Jobs(job_id={self.job_id}, webcode={self.webcode}, status={self.status}, "
+            f"Jobs(job_id={self.job_id}, webcode={self.web_code}, status={self.status}, "
             f"result={self.result}, product_id={self.product_id}, created_at={self.created_at}, "
             f"updated_at={self.updated_at})"
         )
@@ -101,7 +101,7 @@ class JobsCRUD:
     def insert_job(
         self,
         job_id: str,
-        webcode: str,
+        web_code: str,
         status: str,
         result: Optional[str] = None,
         product_id: Optional[int] = None,
@@ -111,7 +111,7 @@ class JobsCRUD:
 
         Args:
             job_id (str): Unique identifier for the job.
-            webcode (str): Product webcode associated with the job.
+            web_code (str): Product webcode associated with the job.
             status (str): Status of the job (e.g., Pending, In Progress, Success, Failed).
             result (Optional[str]): Job result or error message.
             product_id (Optional[int]): ID of the product associated with the job.
@@ -120,7 +120,7 @@ class JobsCRUD:
             bool: True if the job was inserted successfully, False otherwise.
         """
 
-        parameters = {"job_id": job_id, "webcode": webcode, "status": status}
+        parameters = {"job_id": job_id, "web_code": web_code, "status": status}
         if not self._validate_parameters(parameters):
             return False
 
@@ -129,7 +129,7 @@ class JobsCRUD:
                 with session.begin():
                     job = Jobs(
                         job_id=job_id,
-                        webcode=webcode,
+                        web_code=web_code,
                         status=status,
                         result=result,
                         product_id=product_id,

--- a/app/services/database_handler.py
+++ b/app/services/database_handler.py
@@ -109,7 +109,7 @@ class DatabaseHandler:
             }
             self.mongo_client.insert_data(mongo_data)
             logger.debug(
-                f"MongoDB insert successful for webcode: {mongo_data['web_code']}."
+                f"MongoDB insert successful for web_code: {mongo_data['web_code']}."
             )
         except KeyError as e:
             logger.error(f"Missing required key for MongoDB insert: {e}")


### PR DESCRIPTION
This pull request includes several changes to the `app/db/jobs_crud.py` and `app/services/database_handler.py` files to correct the naming convention of the `webcode` attribute to `web_code`. The most important changes are listed below:

Changes to `app/db/jobs_crud.py`:

* Renamed the `webcode` column to `web_code` in the `Jobs` class definition.
* Updated the `__repr__` method to reflect the new `web_code` attribute name.
* Modified the `insert_job` method to use `web_code` instead of `webcode` in both the method parameters and the dictionary used for parameter validation. [[1]](diffhunk://#diff-20561717650f16fc8e4d95a94b7026a93cb151f5517b018ed8f118e9b0c9f600L104-R104) [[2]](diffhunk://#diff-20561717650f16fc8e4d95a94b7026a93cb151f5517b018ed8f118e9b0c9f600L114-R114) [[3]](diffhunk://#diff-20561717650f16fc8e4d95a94b7026a93cb151f5517b018ed8f118e9b0c9f600L123-R123) [[4]](diffhunk://#diff-20561717650f16fc8e4d95a94b7026a93cb151f5517b018ed8f118e9b0c9f600L132-R132)

Changes to `app/services/database_handler.py`:

* Updated the debug log message in the `_store_in_mongo` method to use `web_code` instead of `webcode`.